### PR TITLE
Redirect to null error message from find

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -38,7 +38,7 @@ function autovenv --on-variable PWD -d "Automatic activation of Python virtual e
             # to split "/home". So the lack of a slash is what we do to tell us that "it's time to stop"
             break
         end
-        for _venv_dir in (find "$_tree" -maxdepth 1 -type d)
+        for _venv_dir in (find "$_tree" -maxdepth 1 -type d 2> /dev/null)
             if test -e "$_venv_dir/bin/activate.fish"
                 set _source "$_venv_dir/bin/activate.fish"
                 if test "$autovenv_announce" = "yes"


### PR DESCRIPTION
In my case I get some errors when `find` searches for directories (a permissions issue given a very special use case of my $HOME).

For avoiding error messages that have nothing to do with the functionality of this package, I propose a redirection of errors detected by `find` to `/dev/null`